### PR TITLE
Update Camtrap DP to DwC mapping to make use of parentMediaID

### DIFF
--- a/inst/sql/camtrap-dp/dwc_multimedia.sql
+++ b/inst/sql/camtrap-dp/dwc_multimedia.sql
@@ -7,10 +7,11 @@ Y = included in DwC, N = not included in DwC
 CAMTRAP DP MEDIA
 
 mediaID                         Y: as link to observation
-deploymentID                    N: included at observation level
-sequenceID                      Y: as link to observation
+parentMediaID                   Y: as link to child media files
+deploymentID                    Y
 captureMethod                   ?
-timestamp                       Y
+start                           Y
+end                             N
 filePath                        Y
 fileName                        Y: to sort data
 fileMediatype                   Y
@@ -21,25 +22,9 @@ _id                             N
 
 */
 
--- Observations can be based on sequences (sequenceID) or individual files (mediaID)
--- Make two joins and union to capture both cases without overlap
-WITH observations_media AS (
--- Sequence based observations
-  SELECT obs.observationID, obs.timestamp AS observationTimestamp, med.*
-  FROM observations AS obs
-    LEFT JOIN media AS med ON obs.sequenceID = med.sequenceID
-  WHERE obs.observationType = 'animal' AND obs.mediaID IS NULL
-  UNION
--- File based observations
-  SELECT obs.observationID, obs.timestamp AS observationTimestamp, med.*
-  FROM observations AS obs
-    LEFT JOIN media AS med ON obs.mediaID = med.mediaID
-  WHERE obs.observationType = 'animal' AND obs.mediaID IS NOT NULL
-)
-
 SELECT
 -- occurrenceID
-  obs_med.observationID AS occurrenceID,
+  obs.observationID AS occurrenceID,
 -- creator
 -- providerLiteral
 -- provider
@@ -47,32 +32,45 @@ SELECT
   {metadata$mediaLicense} AS rights,
 -- owner
 -- identifier
-  obs_med.mediaID AS identifier,
+  med.mediaID AS identifier,
 -- type
   CASE
-    WHEN obs_med.fileMediatype LIKE '%video%' THEN 'MovingImage'
+    WHEN med.fileMediatype LIKE '%video%' THEN 'MovingImage'
     ELSE 'StillImage'
   END AS type,
 -- providerManagedID
-  obs_med._id AS providerManagedID,
+  med._id AS providerManagedID,
 -- captureDevice
 --  dep.cameraModel AS captureDevice,
 -- resourceCreationTechnique
-  obs_med.captureMethod AS resourceCreationTechnique,
+  med.captureMethod AS resourceCreationTechnique,
 -- accessURI
-  obs_med.filePath AS accessURI,
+  med.filePath AS accessURI,
 -- format
-  obs_med.fileMediatype AS format,
+  med.fileMediatype AS format,
 -- CreateDate
-  STRFTIME('%Y-%m-%dT%H:%M:%SZ', datetime(obs_med.timestamp, 'unixepoch')) AS createDate
+  STRFTIME('%Y-%m-%dT%H:%M:%SZ', datetime(med.start, 'unixepoch')) AS createDate
 
 FROM
-  observations_media AS obs_med
-  LEFT JOIN deployments AS dep
-    ON obs_med.deploymentID = dep.deploymentID
+  observations AS obs
+  LEFT JOIN media AS parent_med
+    ON obs.mediaID = parent_med.mediaID
+  LEFT JOIN
+    (
+      SELECT
+        *,
+        CASE
+          WHEN parentMediaID IS NULL THEN mediaID -- Make parents their own child
+          ELSE parentMediaID
+        END AS populatedParentMediaID
+      FROM media
+    ) AS med
+    ON med.populatedParentMediaID = parent_med.mediaID
+
+WHERE
+  obs.observationType = 'animal' AND
+  med.filePath IS NOT NULL -- Remove sequences
 
 ORDER BY
--- Order is not retained in observations_media, so important to sort
-  obs_med.observationTimestamp,
-  obs_med.timestamp,
-  obs_med.fileName
+  med.start,
+  med.fileName

--- a/inst/sql/camtrap-dp/dwc_occurrence.sql
+++ b/inst/sql/camtrap-dp/dwc_occurrence.sql
@@ -31,13 +31,17 @@ tags                            Y
 comments                        Y
 _id                             N
 
+CAMTRAP DP MEDIA
+
+mediaID                         Y
+deploymentID                    Y
+start                           Y
+end                             ?
+
 CAMTRAP DP OBSERVATIONS
 
 observationID                   Y
-deploymentID                    Y
-sequenceID                      Y
 mediaID                         N: see dwc_multimedia
-timestamp                       Y
 observationType                 Y: as filter
 cameraSetup                     N
 taxonID                         Y
@@ -107,11 +111,11 @@ SELECT
 
 -- EVENT
 -- eventID
-  obs.sequenceID AS eventID,
+  obs.mediaID AS eventID,
 -- parentEventID
-  obs.deploymentID AS parentEventID,
+  med.deploymentID AS parentEventID,
 -- eventDate                    ISO-8601 in UTC
-  strftime('%Y-%m-%dT%H:%M:%SZ', datetime(obs.timestamp, 'unixepoch')) AS eventDate,
+  strftime('%Y-%m-%dT%H:%M:%SZ', datetime(med.start, 'unixepoch')) AS eventDate,
 -- eventTime                    Included in eventDate
 -- habitat
   dep.habitat AS habitat,
@@ -195,8 +199,10 @@ SELECT
 
 FROM
   observations AS obs
+  LEFT JOIN media AS med
+    ON obs.mediaID = med.mediaID
   LEFT JOIN deployments AS dep
-    ON obs.deploymentID = dep.deploymentID
+    ON med.deploymentID = dep.deploymentID
 
 WHERE
   -- Select biological observations only (excluding observations marked as human, blank, vehicle)
@@ -204,4 +210,4 @@ WHERE
   obs.observationType = 'animal'
 
 ORDER BY
-  obs.timestamp
+  med.start


### PR DESCRIPTION
Write SQL based on new structure, results in same DwC data.