### PR TITLE
50 fix links in vignettes: movepub.rmd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,5 +38,5 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr

--- a/vignettes/movepub.Rmd
+++ b/vignettes/movepub.Rmd
@@ -39,7 +39,7 @@ It consists of:
 
 ```{r}
 reference_data <- "https://datarepository.movebank.org/server/api/core/bitstreams/a6e123b0-7588-40da-8f06-73559bb3ff6b/content"
-gps_data <- "https://www.datarepository.movebank.org/server/api/core/bitstreams/df28a80e-e0c4-49fb-aa87-76ceb2d2b76f/content"
+gps_data <- "https://datarepository.movebank.org/server/api/core/bitstreams/df28a80e-e0c4-49fb-aa87-76ceb2d2b76f/content"
 ```
 
 And its DOI:

--- a/vignettes/movepub.Rmd
+++ b/vignettes/movepub.Rmd
@@ -38,8 +38,8 @@ Here we build a Frictionless Data Package by starting from a directory containin
 It consists of:
 
 ```{r}
-reference_data <- "https://www.datarepository.movebank.org/bitstream/handle/10255/move.379/Migration%20timing%20in%20barnacle%20geese%20%28Svalbard%29%20%28data%20from%20Ko%cc%88lzsch%20et%20al.%20and%20Shariatinajafabadi%20et%20al.%202014%29-reference-data.csv?sequence=3"
-gps_data <- "https://www.datarepository.movebank.org/bitstream/handle/10255/move.378/Migration%20timing%20in%20barnacle%20geese%20%28Svalbard%29%20%28data%20from%20Ko%cc%88lzsch%20et%20al.%20and%20Shariatinajafabadi%20et%20al.%202014%29.csv?sequence=3"
+reference_data <- "https://datarepository.movebank.org/server/api/core/bitstreams/a6e123b0-7588-40da-8f06-73559bb3ff6b/content"
+gps_data <- "https://www.datarepository.movebank.org/server/api/core/bitstreams/df28a80e-e0c4-49fb-aa87-76ceb2d2b76f/content"
 ```
 
 And its DOI:


### PR DESCRIPTION
Two links in the movepub vignette were broken, this is a quick PR to fix them. 

Sarah suggested these links: 

```md
https://datarepository.movebank.org/bitstreams/a6e123b0-7588-40da-8f06-73559bb3ff6b/download
https://datarepository.movebank.org/bitstreams/df28a80e-e0c4-49fb-aa87-76ceb2d2b76f/download
 ```

But they don't plug in as easily as the direct API calls:

``` r
url <- "https://datarepository.movebank.org/bitstreams/a6e123b0-7588-40da-8f06-73559bb3ff6b/download"
readr::read_csv(url)
#> Warning: One or more parsing issues, call `problems()` on your data frame for details,
#> e.g.:
#>   dat <- vroom(...)
#>   problems(dat)
#> Rows: 2151 Columns: 1
#> ── Column specification ────────────────────────────────────────────────────────
#> Delimiter: ","
#> chr (1): <!DOCTYPE html><html lang="en"><head>
#> 
#> ℹ Use `spec()` to retrieve the full column specification for this data.
#> ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message.
#> # A tibble: 2,151 × 1
#>    `<!DOCTYPE html><html lang="en"><head>`                                      
#>    <chr>                                                                        
#>  1 "<meta charset=\"UTF-8\">"                                                   
#>  2 "<base href=\"/\">"                                                          
#>  3 "<title>Movebank</title>"                                                    
#>  4 "<meta name=\"viewport\" content=\"width=device-width,minimum-scale=1\">"    
#>  5 "<meta http-equiv=\"cache-control\" content=\"no-store\">"                   
#>  6 "<link rel=\"stylesheet\" href=\"styles.e382c7dd35ca1222.css\" media=\"print…
#>  7 "</style><style ng-transition=\"dspace-angular\">[_nghost-sc558]{--ds-icon-z…
#>  8 "<body>"                                                                     
#>  9 "<ds-app _nghost-sc125=\"\" ng-version=\"13.3.12\"><ds-themed-root _ngconten…
#> 10 "<script src=\"runtime.f535206ef29e30a6.js\" type=\"module\"></script><scrip…
#> # ℹ 2,141 more rows
```

<sup>Created on 2023-07-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>