### PR TITLE
Update to EML 2.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: movepub
 Title: Prepare Movebank Data for Publication
-Version: 0.3.0
+Version: 0.3.0.9000
 Date: 2024-04-24
 Authors@R: c(
     person("Peter", "Desmet", , "peter.desmet@inbo.be", role = c("aut", "cre"),

--- a/R/write_eml.R
+++ b/R/write_eml.R
@@ -131,18 +131,15 @@ write_eml <- function(doi, directory, contact = NULL, study_id = NULL,
     pub_year <- substr(eml$dataset$pubDate, 1, 4)
     last_para <- paste0(
       # Add span to circumvent https://github.com/ropensci/EML/issues/342
-      "<span></span>Data have been standardized to Darwin Core using the ",
+      "<p>Data have been standardized to Darwin Core using the ",
       "<a href=\"https://inbo.github.io/movepub/\">movepub</a> R package ",
       "and are downsampled to the first GPS position per hour. ",
       "The original data are available in ", first_author, " et al. (",
       pub_year, ", <a href=\"", doi_url, "\">", doi_url, "</a>), ",
       "a deposit of Movebank study <a href=\"", study_url, "\">", study_id,
-      "</a>."
+      "</a>.</p>"
     )
-    eml$dataset$abstract$para <- append(
-      eml$dataset$abstract$para,
-      paste0("<![CDATA[", last_para, "]]>")
-    )
+    eml$dataset$abstract$para <- append(eml$dataset$abstract$para, last_para)
   }
 
   # Update contact and set metadata provider

--- a/movepub.Rproj
+++ b/movepub.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: c863b91d-c904-4c6e-901e-59a247efc7f7
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/_snaps/write_eml/eml.xml
+++ b/tests/testthat/_snaps/write_eml/eml.xml
@@ -81,7 +81,9 @@ Acknowledgements
 
 These data were collected by Bert Dijkstra and Rinus Dillerop from Vogelwerkgroep Assen, in collaboration with the Netherlands Institute of Ecology (NIOO-KNAW), Sovon, Radboud University and the University of Amsterdam (UvA). Funding was provided by the Prins Bernard Cultuurfonds Drenthe, municipality of Assen, IJsvogelfonds (from Birdlife Netherlands and Nationale Postcodeloterij) and the Waterleiding Maatschappij Drenthe. The dataset was published with funding from Stichting NLBIF - Netherlands Biodiversity Information Facility.</para>
       <para>This version adds alt-project-id to the reference-data and references the latest Movebank Attribute Dictionary.</para>
-      <para><![CDATA[<span></span>Data have been standardized to Darwin Core using the <a href="https://inbo.github.io/movepub/">movepub</a> R package and are downsampled to the first GPS position per hour. The original data are available in Dijkstra et al. (2023, <a href="https://doi.org/10.5281/zenodo.10053903">https://doi.org/10.5281/zenodo.10053903</a>), a deposit of Movebank study <a href="https://www.movebank.org/cms/webapp?gwt_fragment=page=studies,path=study1605797471">1605797471</a>.]]></para>
+      <para>
+        <p>Data have been standardized to Darwin Core using the <a href="https://inbo.github.io/movepub/">movepub</a> R package and are downsampled to the first GPS position per hour. The original data are available in Dijkstra et al. (2023, <a href="https://doi.org/10.5281/zenodo.10053903">https://doi.org/10.5281/zenodo.10053903</a>), a deposit of Movebank study <a href="https://www.movebank.org/cms/webapp?gwt_fragment=page=studies,path=study1605797471">1605797471</a>.</p>
+      </para>
     </abstract>
     <keywordSet>
       <keyword>animal movement</keyword>


### PR DESCRIPTION
The IPT (v 3.1.0) updated from EML 2.1.1 to EML 2.2.0, solving https://github.com/ropensci/EML/issues/342. We update our scripts accordingly.